### PR TITLE
WP1 S5: Causal masking utilities + proof obligations

### DIFF
--- a/docs/masking.md
+++ b/docs/masking.md
@@ -1,0 +1,25 @@
+# Causal Masking Proof Obligations (S5)
+
+We use a fixed token layout: k support tokens, 1 query token, 1 aggregator token. Two phases:
+
+- compute: construct CG reductions/state using only support↔support and aggregator↔support communication; query is isolated.
+- readout: query reads from supports (and optionally aggregator) to produce prediction; supports do not read from query.
+
+Mask semantics (mask[i,j] = -∞ blocks attention, 0 allows):
+
+- compute phase:
+  - support→{support, aggregator} allowed
+  - aggregator→support allowed
+  - query→{support, aggregator} blocked
+  - aggregator→query blocked (no backchannel)
+- readout phase:
+  - query→{support, aggregator} allowed
+  - support→query blocked
+
+Obligations:
+
+1. No query→support (or support→query) paths exist in compute phase (no leakage of y).
+2. Aggregator does not route query information back to supports before readout.
+3. Readout occurs in a final phase after CG state is computed.
+
+See `src/lat/masking.py` for mask construction and tests for invariants.

--- a/src/lat/masking.py
+++ b/src/lat/masking.py
@@ -1,0 +1,43 @@
+import numpy as np
+from typing import Literal
+
+
+Role = Literal['support', 'query', 'aggregator']
+
+
+def build_roles(num_support: int) -> np.ndarray:
+	"""Return an array of roles for tokens: [support * k, query, aggregator]."""
+	roles = np.array(['support'] * num_support + ['query', 'aggregator'], dtype=object)
+	return roles
+
+
+def attention_mask(roles: np.ndarray, phase: Literal['compute', 'readout']) -> np.ndarray:
+	"""Construct an attention mask where mask[i,j]=0 allows i to attend to j; -inf blocks.
+	- During 'compute' phase: supports can attend supports and aggregator; aggregator can attend supports; query cannot attend supports or aggregator.
+	- During 'readout' phase: query can attend supports and aggregator; supports cannot attend query.
+	"""
+	n = roles.shape[0]
+	M = np.zeros((n, n), dtype=np.float64)
+	neg_inf = -1e9
+	for i in range(n):
+		for j in range(n):
+			if i == j:
+				continue
+			ri = roles[i]
+			rj = roles[j]
+			if phase == 'compute':
+				if ri == 'support' and rj in ('support', 'aggregator'):
+					pass
+				elif ri == 'aggregator' and rj == 'support':
+					pass
+				else:
+					M[i, j] = neg_inf
+			elif phase == 'readout':
+				if ri == 'query' and rj in ('support', 'aggregator'):
+					pass
+				elif ri == 'support' and rj == 'query':
+					M[i, j] = neg_inf
+				else:
+					# allow supports↔supports and aggregator↔supports if needed
+					pass
+	return M

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,22 @@
+import numpy as np
+from src.lat.masking import build_roles, attention_mask
+
+
+def test_compute_phase_blocks_query_to_support():
+	k = 5
+	roles = build_roles(k)
+	M = attention_mask(roles, phase='compute')
+	# query index is k
+	q = k
+	# support indices 0..k-1 should be blocked as targets from query
+	for j in range(k):
+		assert M[q, j] < -1e8
+
+
+def test_readout_phase_allows_query_to_support():
+	k = 5
+	roles = build_roles(k)
+	M = attention_mask(roles, phase='readout')
+	q = k
+	for j in range(k):
+		assert M[q, j] == 0.0


### PR DESCRIPTION
Implements compute/readout masks preventing querysupport leakage; adds tests and a short proof note. Closes #13.