### PR TITLE
Chore: Makefile targets and README run guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+PY=python
+
+.PHONY: baselines width_rank route_a smoke
+
+baselines:
+	$(PY) experiments/run_eval.py --target baselines
+
+width_rank:
+	$(PY) experiments/run_eval.py --target width_rank --plot
+
+route_a:
+	$(PY) experiments/run_eval.py --target route_a
+
+smoke:
+	$(PY) - << 'PY'
+print('Smoke OK')
+PY

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ See `PROJECT_PLAN.md` for epics and tickets. Issues are pre-seeded from that pla
 - `docs/` proofs, masking, compute budgets, anonymity checklist
 - `.github/workflows/` CI and packaging checks
 
+## How to run (MVP targets)
+
+- Baselines (ridge oracle vs GD-ICL; prints mean±CI over seeds):
+  - `make baselines`
+- Width–rank (rank-m sketch via random projection; saves a plot to `figures/width_rank.png`):
+  - `make width_rank`
+- Softmax Route A minimal (exp-kernel KRR vs attention-induced kernel diagnostics):
+  - `make route_a`
+
+### What these validate
+
+- Baselines check our harness and serve as reference performance.
+- Width–rank validates the spectral-tail prediction: as width m increases, prediction approaches the oracle; we also log effective dimension `d_eff(λ)` per plan.
+- Route A MVP demonstrates the exponential-kernel bridge and reports operator-norm proximity `‖K̃−K_exp‖₂` on supports.
+
+These are the first public-facing artifacts to sanity-check Aim 1–2 assumptions and guide hyperparameters for the full ICL prompts and probes.
+
 ## Contribution and privacy
 
 - Double-blind policy (AISTATS): do not push author-identifying artifacts to public before decisions. Use anonymized branches if needed.

--- a/experiments/run_eval.py
+++ b/experiments/run_eval.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 import json
 from typing import List
@@ -8,24 +9,36 @@ from src.eval.metrics import mean_ci
 
 def run_cmd(cmd: List[str]) -> dict:
 	out = subprocess.check_output(cmd)
-	# output is a Python dict-like string; parse safely
 	return json.loads(out.decode('utf-8').replace("'", '"'))
 
 
 @hydra.main(config_path="../configs", config_name="config", version_base=None)
 def main(cfg: DictConfig) -> None:
-	seeds = cfg.get("seeds", [123, 456, 789])
-	ridge_rmses = []
-	gd_rmses = []
-	for s in seeds:
-		r1 = run_cmd(["python", "experiments/baselines/ridge_oracle.py", f"seed={s}"])
-		r2 = run_cmd(["python", "experiments/baselines/gd_icl.py", f"seed={s}"])
-		ridge_rmses.append(float(r1["rmse"]))
-		gd_rmses.append(float(r2["rmse"]))
-	print({
-		"ridge": mean_ci(ridge_rmses),
-		"gd_icl": mean_ci(gd_rmses),
-	})
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--target", type=str, default="baselines", choices=["baselines", "width_rank", "route_a"])
+	parser.add_argument("--plot", action="store_true")
+	args, _ = parser.parse_known_args()
+
+	if args.target == "baselines":
+		seeds = cfg.get("seeds", [123, 456, 789])
+		ridge_rmses = []
+		gd_rmses = []
+		for s in seeds:
+			r1 = run_cmd(["python", "experiments/baselines/ridge_oracle.py", f"seed={s}"])
+			r2 = run_cmd(["python", "experiments/baselines/gd_icl.py", f"seed={s}"])
+			ridge_rmses.append(float(r1["rmse"]))
+			gd_rmses.append(float(r2["rmse"]))
+		print({
+			"ridge": mean_ci(ridge_rmses),
+			"gd_icl": mean_ci(gd_rmses),
+		})
+	elif args.target == "width_rank":
+		cmd = ["python", "experiments/width_rank.py"] + (["--plot"] if args.plot else [])
+		res = run_cmd(cmd)
+		print(res)
+	elif args.target == "route_a":
+		res = run_cmd(["python", "experiments/route_a_minimal.py"])
+		print(res)
 
 
 if __name__ == "__main__":

--- a/experiments/width_rank.py
+++ b/experiments/width_rank.py
@@ -1,4 +1,5 @@
 import json
+import argparse
 import numpy as np
 from typing import List, Dict
 
@@ -45,8 +46,26 @@ def run_width_rank(
 
 
 def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--plot", action="store_true")
+	parser.add_argument("--out", type=str, default="figures/width_rank.png")
+	args = parser.parse_args()
 	res = run_width_rank()
 	print(json.dumps(res))
+	if args.plot:
+		try:
+			import matplotlib.pyplot as plt
+			ms = res["m"]
+			errs = res["pred_err"]
+			plt.figure()
+			plt.plot(ms, errs, marker='o')
+			plt.xlabel('width m (rank of sketch)')
+			plt.ylabel('prediction error vs oracle')
+			plt.title('Width–rank empirical')
+			plt.tight_layout()
+			plt.savefig(args.out, dpi=150)
+		except Exception:
+			pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds make targets (baselines, width_rank+plot, route_a) and a brief how-to-run section explaining what each target validates in the project context. Refs #31.