### PR TITLE
fix: CI Workflow YAML Syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Smoke test
         run: |
           python - << 'PY'
-import sys
-print('Smoke OK')
-PY
+          import sys
+          print('Smoke OK')
+          PY


### PR DESCRIPTION
Closes CI failure. Indents the HEREDOC content in .github/workflows/ci.yml to comply with YAML syntax.